### PR TITLE
CTP-2416 : correct order of arguments for create_event_raw()

### DIFF
--- a/classes/feature/calsync/main.php
+++ b/classes/feature/calsync/main.php
@@ -109,7 +109,7 @@ class main {
         global $DB;
         $eventsynced = $DB->record_exists('local_o365_calidmap', ['eventid' => $eventid, 'userid' => $muserid]);
         if (!$eventsynced) {
-            return $this->create_event_raw($muserid, $eventid, $subject, $body, $timestart, $timeend, [], [], $calid);
+            return $this->create_event_raw($muserid, $eventid, $subject, $body, $timestart, $timeend, [], $calid, []);
         }
     }
 
@@ -127,8 +127,8 @@ class main {
      * @param string $calid The o365 ID of the calendar to create the event in.
      * @return bool|int The new ID of the calidmap record.
      */
-    public function create_event_raw($muserid, $eventid, $subject, $body, $timestart, $timeend, $attendees, array $other = array(),
-        $calid) {
+    public function create_event_raw($muserid, $eventid, $subject, $body, $timestart, $timeend, $attendees, $calid,
+                                     array $other = array()) {
         global $DB;
         $apiclient = $this->construct_calendar_api($muserid, true);
         $o365upn = utils::get_o365_upn($muserid);

--- a/classes/feature/calsync/task/syncoldevents.php
+++ b/classes/feature/calsync/task/syncoldevents.php
@@ -143,7 +143,7 @@ class syncoldevents extends \core\task\adhoc_task {
                                 }
                             }
                             $calsync->create_event_raw($event->eventuserid, $event->eventid, $subject, $body, $evstart, $evend,
-                                    $subscribersprimary, [], $calid);
+                                    $subscribersprimary, $calid);
                         }
                     } catch (\Exception $e) {
                         mtrace('ERROR: '.$e->getMessage());
@@ -282,7 +282,7 @@ class syncoldevents extends \core\task\adhoc_task {
                                 }
                             }
                             $calsync->create_event_raw($event->eventuserid, $event->eventid, $subject, $body, $evstart, $evend,
-                                    $eventattendees, [], $calid);
+                                    $eventattendees, $calid);
                         }
                     } catch (\Exception $e) {
                         mtrace('ERROR: '.$e->getMessage());
@@ -400,7 +400,7 @@ class syncoldevents extends \core\task\adhoc_task {
                         if (isset($subscription->isprimary) && $subscription->isprimary == 1) {
                             $calid = null;
                         }
-                        $calsync->create_event_raw($userid, $event->eventid, $subject, $body, $evstart, $evend, [], [], $calid);
+                        $calsync->create_event_raw($userid, $event->eventid, $subject, $body, $evstart, $evend, [], $calid);
                     } else {
                         mtrace('Not creating event in Outlook. (Sync settings are inward-only.)');
                     }


### PR DESCRIPTION
no optional arguments before mandatory ones.